### PR TITLE
fix: POST requests without a body result in a 503 on some configurations

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -243,7 +243,7 @@ describe('API v1 POST tests', function() {
   })
 
   it('allows POST requests to be made', function(done) {
-    rw.method('POST').reports().end(function(err, response) {
+    rw.method('POST').reports().send({}).end(function(err, response) {
       response.status.should.equal(200);
       done();
     });


### PR DESCRIPTION
The POST request test fails on the staging server due to its configuration (I think varnish doesn't like the empty body).
